### PR TITLE
fix: fix typo in heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ On the server-side, head tags are stored as a VNode array, so you can render the
 - Testing
 - Support `bodyAttrs`, `htmlAttrs`
 
-## Piror Art
+## Prior Art
 
 Inspired by `react-head`.
 


### PR DESCRIPTION
This fixes a typo in one of the **head**ings (no pun intended :stuck_out_tongue:).